### PR TITLE
Fix clear element(x) with canDeselect

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -122,7 +122,7 @@
         </span>
       </transition>
 
-      <slot v-if="hasSelected && !disabled" name="clear" :clear="clear">
+      <slot v-if="hasSelected && !disabled && canDeselect" name="clear" :clear="clear">
         <a class="multiselect-clear" @click.prevent="clear"></a>
       </slot>
     </div>


### PR DESCRIPTION
Fix clear element(x) showing on the right when canDeselect = false

References this issue: https://github.com/vueform/multiselect/issues/61