### PR TITLE
fix: reexport default export of typescript module

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export * from './Multiselect';
+export { default } from './Multiselect';


### PR DESCRIPTION
This fixes the following when using the module with TS:

```
TS1192: Module '"node_modules/@vueform/multiselect/src/index"' has no default export.
[index.d.ts(1, 1): ]()'export *' does not re-export a default.
```