### PR TITLE
bugfix: ignore Enter key triggered by IME

### DIFF
--- a/src/composables/useKeyboard.js
+++ b/src/composables/useKeyboard.js
@@ -45,7 +45,7 @@ export default function useKeyboard (props, context, dep)
   const preparePointer = () => {
     // When options are hidden and creating tags is allowed
     // no pointer will be set (because options are hidden).
-    // In such case we need to set the pointer manually to the 
+    // In such case we need to set the pointer manually to the
     // first option, which equals to the option created from
     // the search value.
     if (mode.value === 'tags' && !showOptions.value && createOption.value && searchable.value && !groupped.value) {
@@ -67,17 +67,22 @@ export default function useKeyboard (props, context, dep)
         if (iv.value.length === 0) {
           return
         }
-        
+
         update([...iv.value].slice(0,-1))
         break
 
       case 'Enter':
         e.preventDefault()
 
+        if (e.keyCode === 229) {
+          // ignore IME confirmation
+          return
+        }
+
         if (addOptionOn.value.indexOf('enter') === -1 && createOption.value) {
           return
         }
-        
+
         preparePointer()
         selectPointer()
         break
@@ -85,7 +90,7 @@ export default function useKeyboard (props, context, dep)
       case ' ':
         if (!createOption.value && !searchable.value) {
           e.preventDefault()
-          
+
           preparePointer()
           selectPointer()
           return
@@ -93,18 +98,18 @@ export default function useKeyboard (props, context, dep)
 
         if (!createOption.value) {
           return false
-        } 
+        }
 
         if (addOptionOn.value.indexOf('space') === -1 && createOption.value) {
           return
         }
 
         e.preventDefault()
-        
+
         preparePointer()
         selectPointer()
         break
-      
+
       case 'Tab':
       case ';':
       case ',':


### PR DESCRIPTION
Languages like Japanese or Chinese input characters by something called [IME](https://en.wikipedia.org/wiki/Input_method). You may not familiar to this if you only input English characters, but people using IME will have trouble to "Add a new tag" by entering the "Enter" key, because the IME also use Enter key to confirm the user's current input which is different from regular Enter key. 

You can use `event.keyCode === 229` to detect if the event is triggered by IME or a regular Enter key.
This PR fix the bug by add the above logic to the Enter key handler.
(I have tested the code in my environment, which works great)