### PR TITLE
Update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vueform/multiselect",
-  "version": "2.5.7",
+  "version": "3.0.0",
   "private": false,
   "description": "Vue 3 multiselect component with single select, multiselect and tagging options.",
   "license": "MIT",


### PR DESCRIPTION
Updating the package version to reflect BREAKING changes from 2.5.7, breaking backwards compatibility.

The current version causes the package to break in package.json files that list it as ^2.X.X.