### PR TITLE
clear event dispatcher now updates before emiting

### DIFF
--- a/src/composables/useOptions.js
+++ b/src/composables/useOptions.js
@@ -307,8 +307,8 @@ export default function useOptions (props, context, dep)
   }
 
   const clear = () => {
-    context.emit('clear', $this)
     update(nullValue.value)
+    context.emit('clear', $this)
   }
 
   const isSelected = (option) => {


### PR DESCRIPTION
As `select` and `deselect`, do update `modelValue` before emitting their respective events, `clear` now updates before emitting the `clear` event, to make it consistent.