### PR TITLE
clear event dispatcher now updates before emiting

### DIFF
--- a/src/composables/useOptions.js
+++ b/src/composables/useOptions.js
@@ -307,8 +307,8 @@ export default function useOptions (props, context, dep)
   }
 
   const clear = () => {
-    context.emit('clear', $this)
     update(nullValue.value)
+    context.emit('clear', $this)
   }
 
   const isSelected = (option) => {


### PR DESCRIPTION
As `select` and `deselect`, do update `modelValue` before emitting their respective events, `clear` now updates before emitting the `clear` event, to make it consistent.

This change is useful, because when you bind a listener to `select` or `deselect` you may easily use the `ref`  passed to `v-model`, while for the `clear` event listener, `v-model` has not been yet updated which makes it complex to trigger other functions that rely on in the selected value, in my use case I have a reusable filter component that may spawn dozens of multiselect elements based of an array prop with configurations.