### PR TITLE
Fix dislpay of noOptionsText and noResultsText in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ Join our [Discord channel](https://discord.gg/WhX2nG6GTQ) or [open an issue](htt
 | **caret** | `{boolean} true` | Whether should display the caret symbol on the right. |
 | **locale** | `{string} null` | The locale of the multiselect. If a locale is set labels might have an `object` value with different keys for different locales. |
 | **locale** | `{string} 'en'` | The fallback locale. |
-| **noOptionsText** | `{string|object} 'The list is empty'` | The text that should be displayed when options list is empty. It can be an object with different keys for different locales. |
-| **noResultsText** | `{string|object} 'No results found'` | The text that should be displayed when there are no search results. It can be an object with different keys for different locales. |
+| **noOptionsText** | `{string\|object} 'The list is empty'` | The text that should be displayed when options list is empty. It can be an object with different keys for different locales. |
+| **noResultsText** | `{string\|object} 'No results found'` | The text that should be displayed when there are no search results. It can be an object with different keys for different locales. |
 | **openDirection** | `{string} 'bottom'` | Whether the option list should be displayed above or below the multiselect. Possible values: `top\|bottom` |
 | **reverse** | `{boolean} false` | Whether the option list should be reversed. Only works with `groups: false`. |
 | **regex** | `{regex\|string} undefined` | The regex that search input should be tested against when `searchable: true`. |


### PR DESCRIPTION
## What was the problem?
There was a `|` in the content of the table that was not escaped so it was treated as a column separator.

## What does it look like?
### Before
![Screenshot from 2023-06-05 13-36-55](https://github.com/vueform/multiselect/assets/1254342/e550f678-f039-41e0-ac8b-38f9cc6b1e16)
### After
![image](https://github.com/vueform/multiselect/assets/1254342/47cbb39e-2f04-4183-a180-a87cbc315b4c)
