### PR TITLE
Typo fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ Or on an instance level:
 
 ### Styling with Tailwind CSS
 
-To use `Multiselect` with Tailwind CSS first you need install `npm i -D mini-svg-data-url` and add background images to `tailwind.config.js`:
+To use `Multiselect` with Tailwind CSS first you need install `npm i -D mini-svg-data-uri` and add background images to `tailwind.config.js`:
 
 ``` js
 // tailwind.config.js


### PR DESCRIPTION
Typo for `npm i -D mini-svg-data-uri` install command